### PR TITLE
address upstream setuptools issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.0",  
+    "setuptools>=62.3.0,<75.9",  
     "torch>=2.5.1",
     ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
a setuptools update prevents sam2 from being installed

https://github.com/facebookresearch/sam2/issues/611#issuecomment-2741748843

https://github.com/pytorch/pytorch/issues/149658

This updated the dependency range of setuptools so that pip install sam2 can be installed.